### PR TITLE
Add Pico W project structure and documentation for SSD1306 demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# Raspberry Pi Pico W + SSD1306 OLED Demo
+
+MicroPython project for Raspberry Pi Pico W that:
+- initializes an SSD1306 OLED over I2C,
+- draws a Raspberry Pi logo,
+- prints static text,
+- runs a 1-second timer animation loop.
+
+Core firmware behavior is preserved from the provided source.
+
+## Repository Structure
+
+```text
+.
+├── src/
+│   └── main.py
+├── lib/
+├── docs/
+│   ├── architecture.md
+│   └── wiring.md
+├── diagram.json
+└── README.md
+```
+
+## Features
+
+- I2C bus scan and display presence check.
+- OLED init at 128x64.
+- Monochrome framebuffer logo rendering.
+- Text output (`Raspberry Pi`, `Pico`).
+- Infinite timer update (`N sec`) every 1000 ms.
+
+## Hardware
+
+- Raspberry Pi Pico W (RP2040)
+- SSD1306 OLED (I2C, 128x64)
+- Breadboard + jumper wires
+
+See full connection details in [`docs/wiring.md`](docs/wiring.md).
+
+## Software Requirements
+
+- MicroPython firmware for Pico/Pico W
+- `ssd1306.py` driver available on-device (commonly from MicroPython examples or bundle)
+- Thonny, `mpremote`, or similar upload tool
+
+## Run on Real Hardware
+
+1. Flash MicroPython UF2 to Pico W.
+2. Wire components as documented in `docs/wiring.md`.
+3. Copy `src/main.py` to device as `main.py`.
+4. Ensure `ssd1306.py` exists on the board filesystem.
+5. Reset the board.
+
+Expected serial output includes detected I2C address and config; display shows logo/text and timer.
+
+## Run in Wokwi
+
+1. Create a new **Raspberry Pi Pico** MicroPython project in Wokwi.
+2. Replace `diagram.json` with this repository's `diagram.json`.
+3. Paste `src/main.py` into Wokwi `main.py`.
+4. Start simulation.
+
+## Wi-Fi Notes
+
+This project does **not** currently use Wi-Fi. If Wi-Fi is added later:
+- keep credentials in a separate local file (for example `secrets.py`) not committed to git,
+- import at runtime, and
+- provide a redacted template (for example `secrets.example.py`).
+
+## Behavior Preservation
+
+No algorithmic/logic changes were introduced to the provided firmware; only structure and documentation were added.

--- a/diagram.json
+++ b/diagram.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "author": "Anderson Costa",
+  "editor": "wokwi",
+  "parts": [
+    { "type": "wokwi-breadboard-mini", "id": "bb1", "top": 0, "left": 0, "attrs": {} },
+    {
+      "type": "wokwi-pi-pico",
+      "id": "pico",
+      "top": 112,
+      "left": 50,
+      "rotate": 270,
+      "attrs": { "env": "micropython-20220618-v1.19.1" }
+    },
+    { "type": "board-ssd1306", "id": "oled1", "top": 60, "left": 80, "attrs": {} }
+  ],
+  "connections": [
+    [ "bb1:2b.f", "bb1:2t.e", "black", [ "v0" ] ],
+    [ "bb1:3b.f", "bb1:3t.e", "red", [ "v0" ] ],
+    [ "bb1:4b.f", "bb1:4t.e", "purple", [ "v0" ] ],
+    [ "bb1:5b.f", "bb1:5t.e", "orange", [ "v0" ] ],
+    [ "bb1:2t.d", "bb1:12t.d", "black", [ "v0" ] ],
+    [ "bb1:3t.c", "bb1:13t.c", "red", [ "v0" ] ],
+    [ "bb1:4t.b", "bb1:14t.b", "purple", [ "v0" ] ],
+    [ "bb1:5t.a", "bb1:15t.a", "orange", [ "v0" ] ],
+    [ "bb1:12t.e", "oled1:GND", "black", [ "v0" ] ],
+    [ "bb1:13t.e", "oled1:VCC", "red", [ "v0" ] ],
+    [ "bb1:14t.e", "oled1:SCL", "purple", [ "v0" ] ],
+    [ "bb1:15t.e", "oled1:SDA", "orange", [ "v0" ] ],
+    [ "pico:9", "bb1:4b.j", "purple", [ "v0" ] ],
+    [ "pico:8", "bb1:5b.j", "orange", [ "v0" ] ],
+    [ "bb1:2t.a", "bb1:17t.a", "black", [ "v-7.93", "h144" ] ],
+    [ "bb1:15t.d", "bb1:16t.d", "orange", [ "v0" ] ],
+    [ "pico:3V3_EN", "bb1:3b.j", "red", [ "v0" ] ],
+    [ "pico:GND.8", "bb1:2b.j", "black", [ "v0" ] ],
+    [ "pico:GP27", "bb1:4b.j", "purple", [ "v-15", "h-38.25" ] ],
+    [ "pico:GP26", "bb1:5b.j", "orange", [ "v-25", "h-36.92" ] ]
+  ],
+  "dependencies": {}
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,43 @@
+# Firmware Architecture
+
+## Runtime Flow
+
+`main()` executes in this order:
+
+1. `init_i2c(scl_pin=27, sda_pin=26)`
+   - Initializes `I2C(1)` at 200 kHz.
+   - Scans for devices.
+   - Exits if no device is found.
+2. `SSD1306_I2C(128, 64, i2c_dev)`
+   - Binds display driver to the detected bus.
+3. `display_logo(oled)`
+   - Builds a `FrameBuffer` from a 32x32 byte array and blits it to `(96,0)`.
+4. `display_text(oled)`
+   - Writes static label text.
+5. `display_anima(oled)`
+   - Enters infinite loop updating elapsed seconds every 1 second.
+
+## Module Responsibilities
+
+- `machine.Pin`, `machine.I2C`: RP2040 GPIO and I2C peripheral control.
+- `ssd1306.SSD1306_I2C`: Display transport + drawing primitives.
+- `framebuf`: Bitmap buffer abstraction for logo rendering.
+- `utime`: Tick/timing functions for second counter update.
+- `sys`: Early exit when no I2C OLED is detected.
+
+## Files
+
+- `src/main.py`: Main firmware logic (preserved behavior).
+- `diagram.json`: Wokwi hardware topology.
+- `docs/wiring.md`: Electrical mapping and assumptions.
+- `docs/architecture.md`: Firmware design notes.
+
+## Error Handling Behavior
+
+- If no I2C address is found, firmware prints `No I2C Display Found` and exits.
+- If found, prints first I2C address and I2C configuration object to serial console.
+
+## Timing Behavior
+
+- Timer display updates nominally once per second using `utime.sleep_ms(1000)`.
+- Elapsed seconds computed from `utime.ticks_ms()` and `utime.ticks_diff()`.

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -1,0 +1,33 @@
+# Wiring (Raspberry Pi Pico W + SSD1306 I2C)
+
+## Components (from `diagram.json`)
+
+1. `wokwi-pi-pico` (used as Pico board in diagram; target remains Pico W)
+2. `board-ssd1306` (I2C OLED display)
+3. `wokwi-breadboard-mini`
+
+## GPIO / Signal Mapping
+
+Firmware uses:
+- `I2C(1, scl=Pin(27), sda=Pin(26), freq=200000)`
+
+| Function | OLED Pin | Pico W GPIO | Physical Pico Pin (signal pin name) | Notes |
+|---|---|---:|---|---|
+| Ground | GND | — | GND (`GND.8` in diagram) | Common ground |
+| Power | VCC | — | 3.3V rail (`3V3_EN` wired in diagram) | SSD1306 is typically 3.3V-safe |
+| I2C Clock | SCL | GP27 | `GP27` | Used as SCL in code |
+| I2C Data | SDA | GP26 | `GP26` | Used as SDA in code |
+
+## Diagram Interpretation Notes
+
+- The provided Wokwi file includes both generic pin references (`pico:8`, `pico:9`) and explicit net connections (`pico:GP26`, `pico:GP27`) to the same breadboard rows.
+- For firmware correctness, the authoritative mapping is GP27=SCL and GP26=SDA, matching `main.py`.
+- The power net in the diagram is tied via `3V3_EN`; on real hardware, connect OLED VCC to a valid 3V3 supply pin.
+
+## Real-World Wiring Checklist
+
+- [ ] Pico GND ↔ OLED GND
+- [ ] Pico 3V3 ↔ OLED VCC
+- [ ] Pico GP27 ↔ OLED SCL
+- [ ] Pico GP26 ↔ OLED SDA
+- [ ] Keep wires short for cleaner I2C signal integrity

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,67 @@
+from machine import Pin, I2C
+from ssd1306 import SSD1306_I2C
+import framebuf, sys
+import utime
+
+pix_res_x = 128
+pix_res_y = 64
+
+
+def init_i2c(scl_pin, sda_pin):
+    # Initialize I2C device
+    i2c_dev = I2C(1, scl=Pin(scl_pin), sda=Pin(sda_pin), freq=200000)
+    i2c_addr = [hex(ii) for ii in i2c_dev.scan()]
+
+    if not i2c_addr:
+        print('No I2C Display Found')
+        sys.exit()
+    else:
+        print("I2C Address : {}".format(i2c_addr[0]))
+        print("I2C Configuration: {}".format(i2c_dev))
+
+    return i2c_dev
+
+
+def display_logo(oled):
+    # Display the Raspberry Pi logo on the OLED
+    buffer = bytearray(b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00|?\x00\x01\x86@\x80\x01\x01\x80\x80\x01\x11\x88\x80\x01\x05\xa0\x80\x00\x83\xc1\x00\x00C\xe3\x00\x00~\xfc\x00\x00L'\x00\x00\x9c\x11\x00\x00\xbf\xfd\x00\x00\xe1\x87\x00\x01\xc1\x83\x80\x02A\x82@\x02A\x82@\x02\xc1\xc2@\x02\xf6>\xc0\x01\xfc=\x80\x01\x18\x18\x80\x01\x88\x10\x80\x00\x8c!\x00\x00\x87\xf1\x00\x00\x7f\xf6\x00\x008\x1c\x00\x00\x0c \x00\x00\x03\xc0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+    fb = framebuf.FrameBuffer(buffer, 32, 32, framebuf.MONO_HLSB)
+
+    oled.fill(0)
+    oled.blit(fb, 96, 0)
+    oled.show()
+
+
+def display_text(oled):
+    # Display text on the OLED
+    oled.text("Raspberry Pi", 5, 5)
+    oled.text("Pico", 5, 15)
+    oled.show()
+
+
+def display_anima(oled):
+    # Display a simple timer animation on the OLED
+    start_time = utime.ticks_ms()
+
+    while True:
+        elapsed_time = (utime.ticks_diff(utime.ticks_ms(), start_time) // 1000) + 1
+
+        # Clear the specific line by drawing a filled black rectangle
+        oled.fill_rect(5, 40, oled.width - 5, 8, 0)
+
+        oled.text("Timer:", 5, 30)
+        oled.text(str(elapsed_time) + " sec", 5, 40)
+        oled.show()
+        utime.sleep_ms(1000)
+
+
+def main():
+    i2c_dev = init_i2c(scl_pin=27, sda_pin=26)
+    oled = SSD1306_I2C(pix_res_x, pix_res_y, i2c_dev)
+    display_logo(oled)
+    display_text(oled)
+    display_anima(oled)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Motivation

- Provide a clean, well-structured MicroPython repository layout and comprehensive documentation for a Raspberry Pi Pico W project that drives an SSD1306 OLED while preserving the original firmware behavior. 
- Make the hardware wiring, Wokwi simulation, and runtime architecture explicit so maintainers can reproduce and extend the demo without changing core logic.

### Description

- Add `src/main.py` containing the provided MicroPython firmware unchanged in runtime behavior and using `I2C(1, scl=Pin(27), sda=Pin(26))` to drive a 128x64 SSD1306 display. 
- Add `diagram.json` with the Wokwi hardware topology derived from the provided diagram for reproducible simulation. 
- Add `README.md` with project overview, features, software requirements, flashing instructions for real hardware, Wokwi usage steps, and guidance for Wi‑Fi credential handling without exposing secrets. 
- Add `docs/wiring.md` with components list, GPIO pin mapping (GP27=SCL, GP26=SDA), wiring checklist, and `docs/architecture.md` describing runtime flow, module responsibilities, error and timing behavior.

### Testing

- Verified the new repository layout and that the files `src/main.py`, `diagram.json`, `README.md`, `docs/wiring.md`, and `docs/architecture.md` are present and their contents match the intended documentation and firmware. 
- Inspected `src/main.py` to confirm the original initialization, logo/text rendering, and infinite timer loop behavior is preserved. 
- Performed repository-level checks and file content prints to validate documentation completeness. 
- No hardware or simulation execution was performed as part of the automated checks; Wokwi run instructions are provided in `README.md` and `docs/wiring.md` for manual verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2918cd54c832d8fb65a199d668288)